### PR TITLE
Change hardcoded check on first inverter

### DIFF
--- a/MQTTPublisher.cpp
+++ b/MQTTPublisher.cpp
@@ -105,7 +105,7 @@ void MQTTPublisher::handle()
 		auto inverters = goodweCommunicator->getInvertersInfo();
 		for (char cnt = 0; cnt < inverters.size(); cnt++)
 		{
-			if (inverters[0].addressConfirmed)
+			if (inverters[cnt].addressConfirmed)
 			{
 				auto prependTopic = (String("goodwe/") + String(inverters[cnt].serialNumber));
 				if (debugMode)


### PR DESCRIPTION
The for-loop of all inverters did only check for inverters[0] if it was confirmed.